### PR TITLE
fixed local prefix setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ DISCORD_TOKEN={TOKEN}
   ```
 - This will set up auto formatting upon saving a file.
 
+7. To call the bot with the desired prefix locally, 
+
+- Add `LOCAL_BOT_PREFIX= ""` to .env with desired prefix between the double quotes
+
 ## Packages:
 
 **Pydash**

--- a/bot.py
+++ b/bot.py
@@ -21,9 +21,12 @@ intents.members = True  # Subscribe to the privileged members intent.
 
 load_dotenv()
 TOKEN = os.getenv("DISCORD_TOKEN")
+LOCAL_PREFIX = os.getenv("LOCAL_PREFIX")
 
 # Update prefix to be called with bot name.
-bot = commands.Bot(command_prefix=commands.when_mentioned, intents=intents)
+bot = commands.Bot(
+    command_prefix=commands.when_mentioned_or(LOCAL_PREFIX), intents=intents
+)
 
 
 @bot.event

--- a/bot.py
+++ b/bot.py
@@ -21,11 +21,10 @@ intents.members = True  # Subscribe to the privileged members intent.
 
 load_dotenv()
 TOKEN = os.getenv("DISCORD_TOKEN")
-LOCAL_PREFIX = os.getenv("LOCAL_PREFIX")
+LOCAL_BOT_PREFIX = os.getenv("LOCAL_BOT_PREFIX")
 
-# Update prefix to be called with bot name.
 bot = commands.Bot(
-    command_prefix=commands.when_mentioned_or(LOCAL_PREFIX), intents=intents
+    command_prefix=commands.when_mentioned_or(LOCAL_BOT_PREFIX), intents=intents
 )
 
 


### PR DESCRIPTION
# Befor putting PR (put x in bracket if you ran it.);

- [x] Run `pylint $(git ls-files '*.py')` passes

# Overview

Describe your pull request. Attach github issue link

https://github.com/dhmoon91/discord/issues/3

Description: Made .env variable to store the prefix to run locally. To use in local, just add `LOCAL_PREFIX = "!"` or anything within the double quotes in .env file.