### PR TITLE
Issue 11 setup pylint for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true,
+    "python.linting.lintOnSave": true
+}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,22 @@ DISCORD_TOKEN={TOKEN}
 pre-commit install --hook-type pre-push
 ```
 
-8. To call the bot with the desired prefix locally, 
+8. We use `pylint` as base-linter
+(Documentation available here: https://code.visualstudio.com/docs/python/linting)
+
+- Install `pylint`; pip3 install pylint
+- Open `Settings` in VS Code, search for `Terminal`, find `Terminal > Integrated > Env: Linux` and click `Edit in settings.json`
+- Add this line in `settings.json`
+```
+{
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true,
+    "python.linting.lintOnSave": true
+}
+```
+- Now `pylint` will run when you save a file
+
+9. To call the bot with the desired prefix locally, 
 
 - Add `LOCAL_BOT_PREFIX= ""` to .env with desired prefix between the double quotes
 


### PR DESCRIPTION
# Befor putting PR (put x in bracket if you ran it.);

- [x] Run `pylint $(git ls-files '*.py')` passes
<img width="1028" alt="Screen Shot 2021-07-04 at 4 22 41 PM" src="https://user-images.githubusercontent.com/9527124/124398512-118c6580-dce4-11eb-8e93-9ccb91ed8d11.png">
--> None of the files added with this PR had issue with pylint

# Overview
- #11 Part1: Add steps to setup&use pylint on vscode to README
- Add README steps to setup `pylint` with VS Code
- Add `.vscode/settings.json` file as example in git repository