### PR TITLE
Setup pylint with pre-push hook from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        stages: [push]
+        language: system
+        entry: pylint --disable=C0116 --ignore=venv
+        types: [python]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ DISCORD_TOKEN={TOKEN}
   ```
 - This will set up auto formatting upon saving a file.
 
-7. To call the bot with the desired prefix locally, 
+7. To enable `pylint` on `pre-push`, please run following command:
+```
+pre-commit install --hook-type pre-push
+```
+
+8. To call the bot with the desired prefix locally, 
 
 - Add `LOCAL_BOT_PREFIX= ""` to .env with desired prefix between the double quotes
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ riotwatcher
 dataframe_image
 black
 pylint
+pre-commit


### PR DESCRIPTION
# Befor putting PR (put x in bracket if you ran it.);

- [x] Run `pylint $(git ls-files '*.py')` passes
<img width="1028" alt="Screen Shot 2021-07-04 at 6 56 00 PM" src="https://user-images.githubusercontent.com/9527124/124401795-7acaa380-dcf9-11eb-96d0-56f0b94447b0.png">
--> None of the files added with this PR had issue with pylint

# Overview
- #11 Part2: Setup pylint with pre-push hook
- Add `pre-commit` in `requirements.txt`
- Add `.pre-commit-config.yaml` file to run `pylint` on push
- Add setup steps on README