### PR TITLE
Issue 11 change pylint on commit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # Befor putting PR (put x in bracket if you ran it.);
 
-- [ ] Run `pylint $(git ls-files '*.py')` passes
+- [ ] Run `pylint --rcfile=.pylintrc $(git ls-files '*.py')` passes
 
 # Overview
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -19,4 +19,4 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Analysing the code with pylint
         run: |
-          pylint --rcfile=.pylintrc `ls -R|grep .py$|xargs`
+          pylint --rcfile=.pylintrc $(git ls-files '*.py')

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,12 @@ repos:
     hooks:
       - id: pylint
         name: pylint
-        stages: [push]
+        stages: [commit]
         language: system
         entry: pylint
         types: [python]
         args:
-        -   --rcfile=.pylintrc
+        - --rcfile=.pylintrc
+default_language_version:
+  python: python3.9
+default_stages: [commit]

--- a/.pylintrc
+++ b/.pylintrc
@@ -153,7 +153,8 @@ disable=parameter-unpacking,
         too-many-function-args,
         missing-module-docstring,
         cell-var-from-loop,
-        cyclic-import
+        cyclic-import,
+        broad-except
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.pylintrc
+++ b/.pylintrc
@@ -152,8 +152,8 @@ disable=parameter-unpacking,
         too-many-locals,
         too-many-function-args,
         missing-module-docstring,
-        cell-var-from-loop
-
+        cell-var-from-loop,
+        cyclic-import
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/README.md
+++ b/README.md
@@ -32,11 +32,13 @@ DISCORD_TOKEN={TOKEN}
   ```
 - This will set up auto formatting upon saving a file.
 
-7. To enable `pylint` on `pre-push`, please run following command:
+7. To disable `pylint` on `pre-push` and enable on `pre-commit`, please run following command:
 
 ```
-pre-commit install --hook-type pre-push
+pre-commit uninstall --hook-type pre-push
+pre-commit install --hook-type pre-commit
 ```
+After above command, if .git/hooks/pre-commit file has been created, then your pre-commit should work as expected.
 
 8. To call the bot with the desired prefix locally,
 

--- a/bot.py
+++ b/bot.py
@@ -117,7 +117,6 @@ async def help_command(ctx):
                 )
         await ctx.send(embed=create_embed(embed_data))
 
-    # pylint: disable=broad-except
     except Exception:
         err_embed = discord.Embed(
             title="Error",
@@ -190,7 +189,6 @@ async def get_rank(ctx, *, name: str):  # using * for get a summoner name with s
 
         await ctx.send(file=file, embed=create_embed(embed_data))
 
-    # pylint: disable=broad-except
     except Exception as e_values:
         # 404 error means Data not found in API
         if "404" in str(e_values):
@@ -236,7 +234,6 @@ async def get_last_match(ctx, *, name: str):
         )
         # os.remove("df_styled.png")
 
-    # pylint: disable=broad-except
     except Exception as e_values:
         # 404 error means Data not found in API
         if "404" in str(e_values):
@@ -259,7 +256,6 @@ async def get_last_match(ctx, *, name: str):
 
 
 @bot.command(name="add", help="Add the players to the list")
-# pylint: disable=too-many-locals, too-many-branches, too-many-statements
 async def add_summoner(ctx, *, message):
     """Writes list of summoners to local
     json file and sends the list to the bot"""
@@ -366,7 +362,6 @@ async def add_summoner(ctx, *, message):
         # display list of summoners
         await display_current_list_of_summoners(ctx)
 
-    # pylint: disable=broad-except
     except Exception as e_values:
         if "404" in str(e_values):
             error_title = "Invalid Summoner Name"
@@ -443,7 +438,6 @@ async def display_current_list_of_summoners(ctx):
 
         await ctx.send(f"Total Number of Summoners: {total_number_of_players}")
 
-    # pylint: disable=broad-except
     except Exception:
         embed_data = EmbedData()
         embed_data.title = ":warning:   No Summoners in the List"
@@ -453,7 +447,6 @@ async def display_current_list_of_summoners(ctx):
 
 
 @bot.command(name="teams", help="Display two teams")
-# pylint: disable=too-many-locals, too-many-branches
 async def display_teams(ctx):
     """Make and display teams to bot from list of summoners in json"""
     try:
@@ -506,7 +499,6 @@ async def display_teams(ctx):
             )
             await ctx.send(file=file, embed=create_embed(embed_data))
 
-    # pylint: disable=broad-except
     except Exception as e_values:
         if str(e_values) in ["NOT ENOUGH PLAYERS", "NO SUMMONERS IN THE LIST"]:
             error_title = e_values.args[0]
@@ -524,7 +516,6 @@ async def display_teams(ctx):
         await ctx.send(embed=create_embed(embed_data))
 
 
-# pylint: disable=too-many-locals, too-many-branches, too-many-statements
 @bot.command(name="remove", help="Remove player(s) from the list")
 async def remove_summoner(ctx, *, message):
     """Remove summoner(s) from list
@@ -609,7 +600,6 @@ async def remove_summoner(ctx, *, message):
         # display list of summoners
         await display_current_list_of_summoners(ctx)
 
-    # pylint: disable=broad-except
     except Exception as e_values:
         if "Limit Exceeded" in str(e_values) or "Unregistered Summoner(s)" in str(
             e_values
@@ -630,7 +620,6 @@ async def remove_summoner(ctx, *, message):
         await display_current_list_of_summoners(ctx)
 
 
-# pylint: disable=too-many-locals, too-many-branches, too-many-statements
 @bot.command(name="clear", help="Clear player(s) from the list")
 async def clear_list_of_summoners(ctx):
     """Clear out summoners from the list"""
@@ -645,7 +634,6 @@ async def clear_list_of_summoners(ctx):
         # display list of summoners
         await display_current_list_of_summoners(ctx)
 
-    # pylint: disable=broad-except
     except Exception as e_values:
         error_title = f"{e_values}"
         error_description = "Oops! Something went wrong.\nTry again!"

--- a/bot.py
+++ b/bot.py
@@ -349,9 +349,9 @@ async def add_summoner(ctx, *, message):
             # TODO: Simplify this - use base.py - update()
             try:
                 session.commit()
-            except Exception as e_values:
+            except Exception as e_value:
                 session.rollback()
-                raise e_values
+                raise e_value
             finally:
                 session.close()
         else:
@@ -600,9 +600,9 @@ async def remove_summoner(ctx, *, message):
         # TODO: Simplify this - use base.py - update()
         try:
             session.commit()
-        except Exception as e_values:
+        except Exception as e_value:
             session.rollback()
-            raise e_values
+            raise e_value
         finally:
             session.close()
 

--- a/utils/embed_object.py
+++ b/utils/embed_object.py
@@ -2,7 +2,6 @@
 
 
 # pylint: disable=useless-object-inheritance
-# pylint: disable=too-few-public-methods
 class EmbedData(object):
     """Embed Object"""
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -22,7 +22,6 @@ def get_file_path(file_path):
     return join(root_dirname, file_path)
 
 
-# pylint: disable=fixme
 # TODO: Properly check for each fields existence and set values.
 # eg; Currently assumes title, description, color will be in 'embed_object',
 # same for inner objects of 'fields', author object.
@@ -58,7 +57,6 @@ def create_embed(embed_object):
                 )
 
         return embed
-    # pylint: disable=broad-except
     except Exception as e_values:
         print("error embed")
         print(e_values)


### PR DESCRIPTION
# Befor putting PR (put x in bracket if you ran it.);

- [x] Run `pylint $(git ls-files '*.py')` passes
<img width="718" alt="Screen Shot 2021-08-04 at 2 03 45 AM" src="https://user-images.githubusercontent.com/9527124/128130126-a52f007f-6652-4fba-aaf4-2d680cb05b03.png">

# Overview

Describe your pull request. Attach github issue link
- Git Issue: https://github.com/dhmoon91/porobot/issues/11

Changes:
- Modify `pre-push` to `pre-commit`
- Add on README with steps to disable pre-push and enable pre-commit
- Resolve pylint command mismatches (detailed information is available --> https://github.com/dhmoon91/porobot/issues/11#issuecomment-892391634)
![Screen Shot 2021-08-04 at 2 18 54 AM](https://user-images.githubusercontent.com/9527124/128131581-662d009e-5e3e-4813-bccc-dbe9cae779cb.png)
(from https://github.com/dhmoon91/porobot/runs/3238335046?check_suite_focus=true , we can see that the pylint result is identical with local run screenshot posted above)
- Resolve existing pylint issues
- Updated PR template with new pylint command `pylint --rcfile=.pylintrc $(git ls-files '*.py')` which will run against all *.py in this directory